### PR TITLE
All logged-in users should be marked as authenticated

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
@@ -183,9 +183,10 @@ public class GoogleOAuth2SecurityRealm extends SecurityRealm {
                     HttpRequest request = requestFactory.buildGetRequest(url);
 
                     GoogleUserInfo info = request.execute().parseAs(GoogleUserInfo.class);
+                    GrantedAuthority[] authorities = new GrantedAuthority[]{SecurityRealm.AUTHENTICATED_AUTHORITY};
                     // logs this user in.
                     UsernamePasswordAuthenticationToken token =
-                            new UsernamePasswordAuthenticationToken(info.getEmail(), "", new GrantedAuthority[]{});
+                            new UsernamePasswordAuthenticationToken(info.getEmail(), "", authorities);
                     SecurityContextHolder.getContext().setAuthentication(token);
                     // update the user profile.
                     User u = User.get(token.getName());


### PR DESCRIPTION
We use the built-in "authenticated" role in a matrix authorization strategy to grant all employees read-only access to our Jenkins setup. When we tried to switch from the OpenID plugin to google-login, we found out that read-only users were locked out. This seems to be because google-login doesn't grant users the authenticated role by default, though it should be given to all non-anonymous users. The attached patch resolved the issue for us.
