### PR TITLE
No need to define project more than once.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,16 +16,15 @@
     <url>https://github.com/jenkinsci/google-login-plugin</url>
   </scm>
 
-  <project>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Google+Login+Plugin</url>
-    <developers>
-      <developer>
-	<id>recampbell</id>
-	<name>Ryan Campbell</name>
-	<email>ryan.campbell@gmail.com</email>
-      </developer>
-    </developers>
-  </project>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Google+Login+Plugin</url>
+
+  <developers>
+    <developer>
+      <id>recampbell</id>
+      <name>Ryan Campbell</name>
+      <email>ryan.campbell@gmail.com</email>
+    </developer>
+  </developers>
 
   <licenses>
     <license>


### PR DESCRIPTION
This was breaking the build.

```
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project org.jenkins-ci.plugins:google-login:1.0-SNAPSHOT (/Users/kgarland/Downloads/google-login/pom.xml) has 1 error
[ERROR]     Malformed POM /Users/kgarland/Downloads/google-login/pom.xml: Unrecognised tag: 'project' (position: START_TAG seen ...</url>\n  </scm>\n\n  <project>... @19:12)  @ /Users/kgarland/Downloads/google-login/pom.xml, line 19, column 12 -> [Help 2]
[ERROR]
```
