### PR TITLE
Trimming whitespace from client secret input

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
+++ b/src/main/java/org/jenkinsci/plugins/googlelogin/GoogleOAuth2SecurityRealm.java
@@ -101,7 +101,7 @@ public class GoogleOAuth2SecurityRealm extends SecurityRealm {
     @DataBoundConstructor
     public GoogleOAuth2SecurityRealm(String clientId, String clientSecret, String domain) throws IOException {
         this.clientId = clientId;
-        this.clientSecret = Secret.fromString(clientSecret);
+        this.clientSecret = Secret.fromString(clientSecret.trim());
         this.domain = Util.fixEmpty(domain);
     }
 


### PR DESCRIPTION
adding a whitespace trim to the client secret because copy-pasting is hard and whitespace hard to detect in hidden fields. Fixes #5 
